### PR TITLE
Modify makefile for debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@
 
 OUT = delay
 OBJ = main.o dtbuf.o time_ms.o
-CFLAGS = -Wall -g -O3
+CFLAGS += -Wall -g -O3
 
 release: delay
 
 delay: $(OBJ)
-	$(CC) $(CFLAGS) -o $(OUT) $(OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $(OUT) $(OBJ)
 
 $(OBJ): dtbuf.h time_ms.h
 


### PR DESCRIPTION
Add CFLAGS and LDFLAGS to include flags from debian/rules when compiling for debian packaging